### PR TITLE
Enhance chat functionality by adding username color mapping

### DIFF
--- a/src/main/java/sienimetsa/sienimetsa_backend/domain/AppuserRepository.java
+++ b/src/main/java/sienimetsa/sienimetsa_backend/domain/AppuserRepository.java
@@ -1,6 +1,8 @@
 package sienimetsa.sienimetsa_backend.domain;
 
+import java.util.List;
 import java.util.Optional;
+
 import org.springframework.data.repository.CrudRepository;
 
 public interface AppuserRepository extends CrudRepository<Appuser, Long> {
@@ -16,6 +18,8 @@ public interface AppuserRepository extends CrudRepository<Appuser, Long> {
 
     // Find a user by username
     Optional<Appuser> findByUsername(String username);
+
+    List<Appuser> findByUsernameIn(List<String> usernames);
 
     
 }

--- a/src/main/java/sienimetsa/sienimetsa_backend/domain/Message.java
+++ b/src/main/java/sienimetsa/sienimetsa_backend/domain/Message.java
@@ -1,7 +1,12 @@
 package sienimetsa.sienimetsa_backend.domain;
 
-import jakarta.persistence.*;
 import java.time.LocalDateTime;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "message")

--- a/src/main/java/sienimetsa/sienimetsa_backend/web/ChatRestController.java
+++ b/src/main/java/sienimetsa/sienimetsa_backend/web/ChatRestController.java
@@ -1,23 +1,25 @@
 package sienimetsa.sienimetsa_backend.web;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.*;
-
-import sienimetsa.sienimetsa_backend.domain.Message;
-
 import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import sienimetsa.sienimetsa_backend.dto.MessageDTO;
 
 @RestController
 @RequestMapping("/api/chat")
 @CrossOrigin(origins = "*")
-
 public class ChatRestController {
 
     @Autowired
     private ChatService chatService;
 
     @GetMapping("/history")
-    public List<Message> getChatHistory() {
+    public List<MessageDTO> getChatHistory() {
         return chatService.getChatHistory();
     }
 }

--- a/src/main/java/sienimetsa/sienimetsa_backend/web/ChatService.java
+++ b/src/main/java/sienimetsa/sienimetsa_backend/web/ChatService.java
@@ -1,24 +1,57 @@
 package sienimetsa.sienimetsa_backend.web;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import sienimetsa.sienimetsa_backend.domain.Appuser;
+import sienimetsa.sienimetsa_backend.domain.AppuserRepository;
 import sienimetsa.sienimetsa_backend.domain.Message;
 import sienimetsa.sienimetsa_backend.domain.MessageRepository;
-
-import java.util.List;
+import sienimetsa.sienimetsa_backend.dto.MessageDTO;
 
 @Service
 public class ChatService {
 
     @Autowired
     private MessageRepository repository;
-    //user can see old messages/chat history
-    public List<Message> getChatHistory() {
-        return repository.findAllByOrderByTimestampAsc();
+
+    @Autowired
+    private AppuserRepository appuserRepository;
+
+    // Fetches chat history with chatColor included
+    public List<MessageDTO> getChatHistory() {
+        List<Message> messages = repository.findAllByOrderByTimestampAsc();
+
+        // Collect all unique usernames from messages
+        List<String> usernames = messages.stream()
+            .map(Message::getUsername)
+            .distinct()
+            .toList();
+
+        // Fetch all Appusers in one query
+        List<Appuser> users = appuserRepository.findByUsernameIn(usernames);
+
+        // Map usernames to chatColor for quick lookup
+        Map<String, String> userColorMap = users.stream()
+            .collect(Collectors.toMap(Appuser::getUsername, Appuser::getChatColor));
+
+        // Map each Message to a MessageDTO
+        return messages.stream().map(message -> {
+            MessageDTO dto = new MessageDTO();
+            dto.setUsername(message.getUsername());
+            dto.setText(message.getText());
+            dto.setTimestamp(message.getTimestamp());
+            dto.setChatColor(userColorMap.get(message.getUsername()));
+            return dto;
+        }).toList();
     }
-      // Saves messages and deletes the oldest one if the total exceeds 100
-      public Message saveMessage(Message message) {
+
+    // Saves messages and deletes the oldest one if the total exceeds 100
+    public Message saveMessage(Message message) {
         Message savedMessage = repository.save(message);
 
         // Check if the total number of messages exceeds 100


### PR DESCRIPTION
This pull request introduces changes to enhance the chat functionality by including user-specific chat colors in the chat history and improving the structure of the backend code. The updates involve modifications to the `ChatService`, the `ChatRestController`, and related domain classes. Below is a summary of the most important changes:

### Chat functionality improvements:

* **Chat history now includes user-specific chat colors**: The `ChatService` was updated to fetch user-specific `chatColor` values from the `AppuserRepository` and include them in the chat history by mapping `Message` entities to `MessageDTO` objects. This ensures that each message in the chat history is enriched with the corresponding user's chat color. (`src/main/java/sienimetsa/sienimetsa_backend/web/ChatService.java`)

* **New repository method for bulk user retrieval**: A new method `findByUsernameIn(List<String> usernames)` was added to `AppuserRepository` to enable efficient bulk retrieval of `Appuser` entities by their usernames. (`src/main/java/sienimetsa/sienimetsa_backend/domain/AppuserRepository.java`)

### Code structure and clarity improvements:

* **Refactored `ChatRestController` to use `MessageDTO`**: The `getChatHistory` endpoint in `ChatRestController` was updated to return a list of `MessageDTO` objects instead of `Message` entities, aligning the API response with the new enriched chat history structure. (`src/main/java/sienimetsa/sienimetsa_backend/web/ChatRestController.java`)

* **Added missing imports to `Message` class**: The `Message` entity now explicitly imports all required JPA annotations, improving clarity and ensuring compatibility with the persistence framework. (`src/main/java/sienimetsa/sienimetsa_backend/domain/Message.java`)